### PR TITLE
Add option to configure copy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,12 @@ Clone this repo somewhere and source `tmux-copy-output.tmux` at the config file.
 The default key-binding is `g`(of course prefix hit is needed), it can be modified by setting value to `@tco-key` at tmux config file.
 There is also an option to set which launcher to use. By default it is `fzf-tmux`, you can use `dmenu` or any custom command.
 
+The default copy to clipboard command is `xclip` for Linux systems. It's possible to override the command with `@tco-copy`.
+
 ``` tmux
 set -g @tco-key 'k'
 set -g @tco-launcher 'dmenu -c -l 30 -bw 2'
+set -g @tco-copy 'pbcopy'
 ```
 ## Acknowledgements
 Copy script hugely inspired on:

--- a/tmux-copy-output.sh
+++ b/tmux-copy-output.sh
@@ -16,6 +16,7 @@ launcher_cmd() {
 }
 
 launcher=$1
+copy=$2
 content="$(tmux capture-pane -pS -32768)"
 # Get PS1 prompt
 ps1="$(echo "$content" |
@@ -34,4 +35,4 @@ eps1="$(echo "$ps1" | sed 's/[^^]/[&]/g; s/\^/\\^/g')"
 
 echo "$content" |
   awk "/^$chosen$/{p=1;print;next} p&&/$eps1/{p=0};p" |
-  xclip -selection clipboard
+  $copy

--- a/tmux-copy-output.tmux
+++ b/tmux-copy-output.tmux
@@ -16,6 +16,7 @@ tmux_get() {
 
 key="$(tmux_get '@tco-key' 'g')"
 launcher="$(tmux_get '@tco-launcher' 'fzf-tmux')"
+copy="$(tmux_get '@tco-copy' 'xclip -selection clipboard')"
 
 tmux bind-key "$key" run -b "$CURRENT_DIR/tmux-copy-output.sh \"$launcher\"";
 

--- a/tmux-copy-output.tmux
+++ b/tmux-copy-output.tmux
@@ -18,5 +18,5 @@ key="$(tmux_get '@tco-key' 'g')"
 launcher="$(tmux_get '@tco-launcher' 'fzf-tmux')"
 copy="$(tmux_get '@tco-copy' 'xclip -selection clipboard')"
 
-tmux bind-key "$key" run -b "$CURRENT_DIR/tmux-copy-output.sh \"$launcher\"";
+tmux bind-key "$key" run -b "$CURRENT_DIR/tmux-copy-output.sh \"$launcher\" \"$copy\"";
 


### PR DESCRIPTION
On MacOS the copy command is `pbcopy`

I've included `@tco-copy` option in the plugin so that it's possible to override that value.